### PR TITLE
Pushing new docker image automatically

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,19 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: vibpsb/mini-ex
+          tags: latest


### PR DESCRIPTION
This GitHub action keeps your Docker image up to date every time you make a release or if you trigger it yourselves using the button in the actions tab of this repo.