### PR TITLE
removing the python/x86_64/3.6.5 restriction

### DIFF
--- a/miniex.nf
+++ b/miniex.nf
@@ -137,8 +137,6 @@ process filter_expression {
 }
 
 process make_info_file {
-
-	module 'python/x86_64/3.6.5'
 	publishDir regOutput, mode: 'copy'
 
     input:


### PR DESCRIPTION
The 3.6.5 version of python isn't available in the mini-ex image, which breaks the call to MINIEX_makeInfoFile.py. This is related to issue https://github.com/VIB-PSB/MINI-EX/issues/5.